### PR TITLE
feat: add optional parameters to bats

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -27,6 +27,7 @@ workflows:
           name: test-bats-junit
           path: src/tests
           formatter: junit
+          timing: true
           filters: *filters
       - orb-tools/publish:
           orb-name: circleci/bats

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,7 +20,13 @@ workflows:
       - test-install:
           filters: *filters
       - bats/run:
+          name: test-bats
           path: src/tests
+          filters: *filters
+      - bats/run:
+          name: test-bats-junit
+          path: src/tests
+          formatter: junit
           filters: *filters
       - orb-tools/publish:
           orb-name: circleci/bats
@@ -30,6 +36,8 @@ workflows:
           github-token: GHI_TOKEN
           requires:
             - orb-tools/pack
+            - test-bats-junit
+            - test-bats
             - test-install
           context: orb-publisher
           filters:

--- a/src/examples/run-bats-tests.yml
+++ b/src/examples/run-bats-tests.yml
@@ -1,11 +1,18 @@
 description: >
-  The "run" job provided by the BATS orb will automatically checkout your repository and execute BATS tests within the given path. See the GitHub README for more resources on creating BATS tests.
+  The "run" job provided by the BATS orb will automatically checkout your repository and execute BATS tests within the given path.
+  Optionally, specify the 'junit' formatter and enable timing to generate a JUnit XML file for CircleCI test reporting.
+  Junit test reports will be automatically collected.
+
+  See the GitHub README for more resources on creating BATS tests.
+
 usage:
   version: 2.1
   orbs:
-    bats: circleci/bats@1.0.1
+    bats: circleci/bats@1.1.0
   workflows:
     test-my-app:
       jobs:
         - bats/run:
             path: ./src/tests
+            formatter: junit
+            timing: true

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -5,10 +5,32 @@ parameters:
   path:
     description: "REQUIRED: Path containing BATS test script(s)"
     type: string
+
+  formatter:
+    description: "Formatter to use for output. Select `junit` for CircleCI test reporting. You can also supply a custom formatter."
+    type: string
+    default: "tap"
+
+  timing:
+    description: "Add timing information to the tests. Recommended for CircleCI test reporting."
+    type: boolean
+    default: false
+
+  output:
+    description: "Write the results to a file. Ensure the filetype matches the formatter."
+    type: string
+    default: "/tmp/bats/results.xml"
+
+  args:
+    description: "Additional arguments to pass to the BATS command. e.x: `--recursive --trace`"
+    type: string
+    default: ""
+
   setup-steps:
     description: Add additional steps prior to executing tests. Additional BATS plugins can be loaded here, or other setup scripts.
     type: steps
     default: []
+
   exec_environment:
     description: Set a custom executor for your BATS testing environment. By default the Docker image 'cimg/base:stable' will be used. BATS will be installed at run time.
     type: executor
@@ -24,4 +46,7 @@ steps:
       name: Execute BATS tests
       environment:
         ORB_VAL_PATH: <<parameters.path>>
+        ORB_VAL_FORMATTER: tap
+        ORB_VAL_OUTPUT: <<parameters.output>>
+        ORB_VAL_ARGS: <<parameters.args>>
       command: <<include(scripts/run-bats.sh)>>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -49,6 +49,7 @@ steps:
         ORB_VAL_FORMATTER: <<parameters.formatter>>
         ORB_VAL_OUTPUT: <<parameters.output>>
         ORB_VAL_ARGS: <<parameters.args>>
+        ORB_VAL_TIMING: <<parameters.timing>>
       command: <<include(scripts/run-bats.sh)>>
   - when:
       condition:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -46,7 +46,12 @@ steps:
       name: Execute BATS tests
       environment:
         ORB_VAL_PATH: <<parameters.path>>
-        ORB_VAL_FORMATTER: tap
+        ORB_VAL_FORMATTER: <<parameters.formatter>>
         ORB_VAL_OUTPUT: <<parameters.output>>
         ORB_VAL_ARGS: <<parameters.args>>
       command: <<include(scripts/run-bats.sh)>>
+  - when:
+      equal: ["junit", <<parameters.formatter>>]
+      steps:
+        - store_test_results:
+            path: <<parameters.output>>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -51,7 +51,8 @@ steps:
         ORB_VAL_ARGS: <<parameters.args>>
       command: <<include(scripts/run-bats.sh)>>
   - when:
-      equal: ["junit", <<parameters.formatter>>]
+      condition:
+        equal: ["junit", <<parameters.formatter>>]
       steps:
         - store_test_results:
             path: <<parameters.output>>

--- a/src/scripts/run-bats.sh
+++ b/src/scripts/run-bats.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
 # This script is ran within the 'run' job, which will check 
 #   for the existence of BATS prior to running this script.
-bats "$ORB_VAL_PATH"
+
+# Attempt to create the output directory
+mkdir -p "$(dirname "$ORB_VAL_OUTPUT")" || { echo "Failed to create output directory"; exit 1; }
+
+if [ "$ORB_VAL_TIMING" = "true" ]; then
+  set -- "$@" --timing
+fi
+
+# Ensure this is the last argument
+if [ -n "$ORB_VAL_ARGS" ]; then
+  set -- "$@" "$ORB_VAL_ARGS"
+fi
+
+set -x
+bats --formatter "$ORB_VAL_FORMATTER" "$@" "$ORB_VAL_PATH" | tee "$ORB_VAL_OUTPUT"
+set +x

--- a/src/scripts/run-bats.sh
+++ b/src/scripts/run-bats.sh
@@ -5,7 +5,7 @@
 # Attempt to create the output directory
 mkdir -p "$(dirname "$ORB_VAL_OUTPUT")" || { echo "Failed to create output directory"; exit 1; }
 
-if [ "$ORB_VAL_TIMING" = "true" ]; then
+if [ "$ORB_VAL_TIMING" = "1" ]; then
   set -- "$@" --timing
 fi
 


### PR DESCRIPTION
- Adds optional parameters to modify the flags of the bats command.
- If the junit parameter is set to true, the test results will automatically be saved to CircleCI

This PR is designed to add the features while not enabling them by default to ensure backwards compatibility. We can revisit changing default values in a major version change.

by default, the output will now look a little different, and you can see the TAP output is being saved as `results.xml`, as this is assuming you want to save junit by default, but will currently default to the TAP formatter for minor compatibility.
<img width="433" alt="image" src="https://user-images.githubusercontent.com/33272306/203436416-f2c9c7bb-f786-48f2-82c9-23ce904c6656.png">

If you set to junit, you will now have circleci test results. Timing data can be enabled with a parameter, this will be default in the future.

<img width="880" alt="image" src="https://user-images.githubusercontent.com/33272306/203437046-c6507057-5475-47d3-820e-f9506ffa2ad4.png">

resolves:
 - #4 
 - #6  
