### PR TITLE
feat: always report junit, print tap

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,6 +29,12 @@ workflows:
           formatter: junit
           timing: true
           filters: *filters
+      - bats/run:
+          name: test-bats-junit-multi-path
+          path: src/tests src/tests2
+          formatter: junit
+          timing: true
+          filters: *filters
       - orb-tools/publish:
           orb-name: circleci/bats
           vcs-type: << pipeline.project.type >>
@@ -40,6 +46,7 @@ workflows:
             - test-bats-junit
             - test-bats
             - test-install
+            - test-bats-junit-multi-path
           context: orb-publisher
           filters:
             branches:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,4 +1,3 @@
-
 description: >
   Install the BATS-Core BASH Automation Testing System.
 steps:

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -41,6 +41,11 @@ parameters:
     type: executor
     default: default
 
+  save_test_results:
+    description: Save test results to CircleCI. This is only necessary if you are using the `junit` formatter.
+    type: boolean
+    default: true
+
 executor: <<parameters.exec_environment>>
 
 steps:
@@ -53,13 +58,13 @@ steps:
         ORB_VAL_PATH: <<parameters.path>>
         ORB_VAL_FORMATTER: <<parameters.formatter>>
         ORB_VAL_REPORT_FORMATTER: <<parameters.report_formatter>>
+        ORB_VAL_SAVE_TEST_RESULTS: <<parameters.save_test_results>>
         ORB_VAL_OUTPUT: <<parameters.output>>
         ORB_VAL_ARGS: <<parameters.args>>
         ORB_VAL_TIMING: <<parameters.timing>>
       command: <<include(scripts/run-bats.sh)>>
   - when:
-      condition:
-        equal: ["junit", <<parameters.report_formatter>>]
+      condition: <<parameters.save_test_results>>
       steps:
         - store_test_results:
             path: <<parameters.output>>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -12,7 +12,9 @@ parameters:
     default: "tap"
 
   report_formatter:
-    description: "Formatter to use for test report output. Select `junit` for CircleCI test reporting. You can also supply a custom formatter."
+    description:
+      Formatter to use for test report output. By default, "junit" will be selected and parsed by CircleCI.
+      If a non-junit compatible formatter is selected, "save_test_results" should be set to false.
     type: string
     default: "junit"
 
@@ -42,7 +44,9 @@ parameters:
     default: default
 
   save_test_results:
-    description: Save test results to CircleCI. This is only necessary if you are using the `junit` formatter.
+    description:
+      Save test results to CircleCI. Note, your formatter must be 'junit' to be parsed by CircleCI.
+      If the report format has been changed, or if you do not wish for the test results to be displayed within CircleCI, then set this to 'false'
     type: boolean
     default: true
 

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -7,9 +7,14 @@ parameters:
     type: string
 
   formatter:
-    description: "Formatter to use for output. Select `junit` for CircleCI test reporting. You can also supply a custom formatter."
+    description: "Formatter to use for output seen in the step UI. You can also supply a custom formatter."
     type: string
     default: "tap"
+
+  report_formatter:
+    description: "Formatter to use for test report output. Select `junit` for CircleCI test reporting. You can also supply a custom formatter."
+    type: string
+    default: "junit"
 
   timing:
     description: "Add timing information to the tests. Recommended for CircleCI test reporting."
@@ -17,9 +22,9 @@ parameters:
     default: false
 
   output:
-    description: "Write the results to a file. Ensure the filetype matches the formatter."
+    description: "Write the report results to a file in this given path."
     type: string
-    default: "/tmp/bats/results.xml"
+    default: "/tmp/bats"
 
   args:
     description: "Additional arguments to pass to the BATS command. e.x: `--recursive --trace`"
@@ -47,13 +52,14 @@ steps:
       environment:
         ORB_VAL_PATH: <<parameters.path>>
         ORB_VAL_FORMATTER: <<parameters.formatter>>
+        ORB_VAL_REPORT_FORMATTER: <<parameters.report_formatter>>
         ORB_VAL_OUTPUT: <<parameters.output>>
         ORB_VAL_ARGS: <<parameters.args>>
         ORB_VAL_TIMING: <<parameters.timing>>
       command: <<include(scripts/run-bats.sh)>>
   - when:
       condition:
-        equal: ["junit", <<parameters.formatter>>]
+        equal: ["junit", <<parameters.report_formatter>>]
       steps:
         - store_test_results:
             path: <<parameters.output>>

--- a/src/jobs/run.yml
+++ b/src/jobs/run.yml
@@ -19,7 +19,7 @@ parameters:
   timing:
     description: "Add timing information to the tests. Recommended for CircleCI test reporting."
     type: boolean
-    default: false
+    default: true
 
   output:
     description: "Write the report results to a file in this given path."

--- a/src/scripts/run-bats.sh
+++ b/src/scripts/run-bats.sh
@@ -3,7 +3,7 @@
 #   for the existence of BATS prior to running this script.
 
 # Attempt to create the output directory
-mkdir -p "$(dirname "$ORB_VAL_OUTPUT")" || { echo "Failed to create output directory"; exit 1; }
+mkdir -p "$ORB_VAL_OUTPUT" || { echo "Failed to create output directory"; exit 1; }
 
 if [ "$ORB_VAL_TIMING" = "1" ]; then
   set -- "$@" --timing
@@ -15,5 +15,5 @@ if [ -n "$ORB_VAL_ARGS" ]; then
 fi
 
 set -x
-bats --formatter "$ORB_VAL_FORMATTER" "$@" "$ORB_VAL_PATH" | tee "$ORB_VAL_OUTPUT"
+bats --formatter "$ORB_VAL_FORMATTER" --report-formatter "$ORB_VAL_REPORT_FORMATTER" "$@" --output "$ORB_VAL_OUTPUT" "$ORB_VAL_PATH" 
 set +x

--- a/src/scripts/run-bats.sh
+++ b/src/scripts/run-bats.sh
@@ -15,5 +15,6 @@ if [ -n "$ORB_VAL_ARGS" ]; then
 fi
 
 set -x
-bats --formatter "$ORB_VAL_FORMATTER" --report-formatter "$ORB_VAL_REPORT_FORMATTER" "$@" --output "$ORB_VAL_OUTPUT" "$ORB_VAL_PATH" 
+#shellcheck disable=SC2086
+bats --formatter "$ORB_VAL_FORMATTER" --report-formatter "$ORB_VAL_REPORT_FORMATTER" "$@" --output "$ORB_VAL_OUTPUT" $ORB_VAL_PATH 
 set +x

--- a/src/tests2/test.bats
+++ b/src/tests2/test.bats
@@ -1,0 +1,26 @@
+setup() {
+  if ! command -v bc &> /dev/null; then
+    sudo apt install bc
+  fi
+}
+
+@test "4: Get the 1000th digit of pi" {
+    # https://stackoverflow.com/a/23524782
+    pi=$(echo "scale=1000; 4*a(1)" | bc -l;)
+    last_digit=${pi: -1}
+    [[ $last_digit == "8" ]]
+}
+
+@test "5: Wait 2 seconds" {
+    start=$(date +%s)
+    sleep 2
+    end=$(date +%s)
+    [[ $((end - start)) -ge 2 ]]
+}
+
+@test "6: Add random sleep between 1-5 seconds" {
+    start=$(date +%s)
+    sleep $((RANDOM % 5 + 1))
+    end=$(date +%s)
+    [[ $((end - start)) -ge 1 ]]
+}


### PR DESCRIPTION
Refactors the changes made in #11 (not yet released) based on suggestions from #6 to resolve #4.

The report and console output are not required to be the same format. This PR now changes it so that reports are always generated in XML with timing data by default and saving the test results. This is all done without large changes to the UI output which currently prints in TAP by default. 